### PR TITLE
Add notebooks to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,8 +79,12 @@ HERE = pathlib.Path(os.path.abspath(os.path.dirname(__file__)))
 
 
 files_to_copy = [
-    "contextily_guide.ipynb",
-    "warping_guide.ipynb",
+    "notebooks/add_basemap_deepdive.ipynb",
+    "notebooks/intro_guide.ipynb",
+    "notebooks/places_guide.ipynb",
+    "notebooks/providers_deepdive.ipynb",
+    "notebooks/warping_guide.ipynb",
+    "notebooks/working_with_local_files.ipynb",
     "tiles.png"
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,8 +12,12 @@ Contents
 .. toctree::
    :maxdepth: 2
 
-   contextily_guide
+   intro_guide
+   places_guide
    warping_guide
+   add_basemap_deepdive
+   working_with_local_files
+   providers_deepdive
    reference
 
 


### PR DESCRIPTION
This ensures the notebooks are added to the docs (and thus show up on https://contextily.readthedocs.io/en/latest/)