### PR TITLE
Use Cape Town consistently in description and variable names

### DIFF
--- a/notebooks/working_with_local_files.ipynb
+++ b/notebooks/working_with_local_files.ipynb
@@ -213,7 +213,7 @@
    "source": [
     "### Raster from name\n",
     "\n",
-    "The other option `contextily` includes to save rasters is through its Place API, which allows you to query locations through their names (thanks to [`geopy`](https://geopy.readthedocs.io/en/stable/)). For example, we can retrieve a basemap of Sao Paulo:"
+    "The other option `contextily` includes to save rasters is through its Place API, which allows you to query locations through their names (thanks to [`geopy`](https://geopy.readthedocs.io/en/stable/)). For example, we can retrieve a basemap of Cape Town:"
    ]
   },
   {
@@ -245,8 +245,8 @@
     }
    ],
    "source": [
-    "sao_paulo = ctx.Place(\"Cape Town\", source=ctx.providers.Wikimedia)\n",
-    "sao_paulo.plot()"
+    "cape_town = ctx.Place(\"Cape Town\", source=ctx.providers.Wikimedia)\n",
+    "cape_town.plot()"
    ]
   },
   {
@@ -262,7 +262,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sao_paulo = ctx.Place(\"Cape Town\", source=ctx.providers.Wikimedia, path=\"cape_town.tif\")"
+    "cape_town = ctx.Place(\"Cape Town\", source=ctx.providers.Wikimedia, path=\"cape_town.tif\")"
    ]
   },
   {


### PR DESCRIPTION
Fixes a small inconsistency in the docs where the text and variable names were about Sao Paolo but the data used was for Cape Town.