### PR TITLE
Close and reopen memfile dataset before WarpedVRT

### DIFF
--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -411,13 +411,14 @@ def _warper(img, transform, s_crs, t_crs, resampling):
             crs=s_crs,
             transform=transform,
         ) as mraster:
-            for band in range(b):
-                mraster.write(img[band, :, :], band + 1)
-            # --- Virtual Warp
+            mraster.write(np.moveaxis(img, 0, -1))
+    
+        with memfile.open() as mraster
             with WarpedVRT(mraster, crs=t_crs, resampling=resampling) as vrt:
                 img = vrt.read()
                 bounds = vrt.bounds
                 transform = vrt.transform
+    
     return img, bounds, transform
 
 

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -411,7 +411,7 @@ def _warper(img, transform, s_crs, t_crs, resampling):
             crs=s_crs,
             transform=transform,
         ) as mraster:
-            mraster.write(np.moveaxis(img, 0, -1))
+            mraster.write(img)
     
         with memfile.open() as mraster:
             with WarpedVRT(mraster, crs=t_crs, resampling=resampling) as vrt:

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -413,7 +413,7 @@ def _warper(img, transform, s_crs, t_crs, resampling):
         ) as mraster:
             mraster.write(np.moveaxis(img, 0, -1))
     
-        with memfile.open() as mraster
+        with memfile.open() as mraster:
             with WarpedVRT(mraster, crs=t_crs, resampling=resampling) as vrt:
                 img = vrt.read()
                 bounds = vrt.bounds


### PR DESCRIPTION
Depending on format, datasets that have been written need to be closed before they are complete, so this is safer. A future version of rasterio will require that datasets passed to WarpedVRT be opened in read-only mode. Also, using numpy.moveaxis so that we only call mraster.write once.