### PR TITLE
DOC: captions + update for latest pydata-sphinx-theme

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,21 +1,17 @@
 /* Override some aspects of the pydata-sphinx-theme */
 
 :root {
-  --color-active-navigation: 0, 91, 129;
+  --pst-color-active-navigation: 0, 91, 129;
   /* Use normal text color (like h3, ..) instead of primary color */
-  --color-h1: var(--color-text-base);
-  --color-h2: var(--color-text-base);
-}
-
-
-body {
-  padding-top: 0px;
+  --pst-color-h1: var(--pst-color-text-base);
+  --pst-color-h2: var(--pst-color-text-base);
+  --pst-header-height: 0px;
 }
 
 @media (min-width: 768px) {
   @supports (position: -webkit-sticky) or (position: sticky) {
     .bd-sidebar {
-      top: 40px;
+      padding-top: 3rem;
     }
   }
 }

--- a/docs/_templates/docs-sidebar.html
+++ b/docs/_templates/docs-sidebar.html
@@ -14,21 +14,10 @@ CONTEXTILY
 <form class="bd-search d-flex align-items-center" action="{{ pathto('search') }}" method="get">
     <i class="icon fas fa-search"></i>
     <input type="search" class="form-control" name="q" id="search-input" placeholder="{{ theme_search_bar_text }}" aria-label="{{ theme_search_bar_text }}" autocomplete="off" >
-  </form>
-  
-  <nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
-  
-    <div class="bd-toc-item active">
-    {% set nav = get_nav_object(maxdepth=3, collapse=True) %}
-  
+</form>
 
-
-    <ul class="nav bd-sidenav">
-        {% for nav_item in nav %}
-        <li class="nav-item {% if nav_item.active%}active{% endif %}">
-            <a class="nav-link" href="{{ nav_item.url }}">{{ nav_item.title }}</a>
-        </li>
-        {% endfor %}
-    </ul>
-  
-  </nav>
+<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+  <div class="bd-toc-item active">
+    {{ generate_nav_html("sidebar", startdepth=0, maxdepth=4, collapse=False, includehidden=True, titles_only=True) }}
+  </div>
+</nav>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,9 +1,5 @@
 {% extends "pydata_sphinx_theme/layout.html" %}
 
-<!-- Docs TOC is "d-none d-xl-block col-xl-2" -->
-
 {# Silence the navbar #}
 {% block docs_navbar %}
 {% endblock %}
-
-

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,5 +18,4 @@ dependencies:
 - nbsphinx
 - pandoc
 - ipython
-- pip:
-  - git+https://github.com/pandas-dev/pydata-sphinx-theme.git@master
+- pydata-sphinx-theme

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,12 +11,18 @@ Contents
 
 .. toctree::
    :maxdepth: 2
+   :caption: User Guide
 
    intro_guide
    warping_guide
    working_with_local_files
    providers_deepdive
    friends_gee
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference Guide
+
    reference
 
 


### PR DESCRIPTION
This updates for the latest version of the theme (eg we were still using the variable names of the unreleased version, and those were changed). 
Further, it also makes use of some new features.

One of them is that we can now have **captions** in the sidebar. @darribas I seem to remember that you initially wanted this when we made the docs (but at that time I said that the theme didn't yet support it, but would so in the future). I am only not sure what would be useful distinctions. What I tried out now gives:

![image](https://user-images.githubusercontent.com/1020496/113475148-21da3d80-9474-11eb-8c1d-137d5447e289.png)

Do we want something like that? (right now, the "reference guide" is a bit duplicated between the caption and the actual link ..)