### PR TITLE
Providers: Add Esri World Dark Gray Canvas basemap

### DIFF
--- a/contextily/_providers.py
+++ b/contextily/_providers.py
@@ -447,6 +447,13 @@ providers = Bunch(
             attribution = 'Tiles (C) Esri -- Esri, DeLorme, NAVTEQ',
             max_zoom = 16,
             name = 'Esri.WorldGrayCanvas'
+        ),
+        WorldDarkGrayCanvas = TileProvider(
+            url = 'https://server.arcgisonline.com/ArcGIS/rest/services/{variant}/MapServer/tile/{z}/{y}/{x}',
+            variant = 'Canvas/World_Dark_Gray_Base',
+            attribution = 'Tiles (C) Esri -- Esri, DeLorme, NAVTEQ',
+            max_zoom = 16,
+            name = 'Esri.WorldDarkGrayCanvas'
         )
     ),
     OpenWeatherMap = Bunch(


### PR DESCRIPTION
Adds the Esri World Dark Gray Canvas basemap to the provider list.

See:
 - https://www.arcgis.com/home/item.html?id=1970c1995b8f44749f4b9b6e81b5ba45
 - https://server.arcgisonline.com/arcgis/rest/services/Canvas/World_Dark_Gray_Base/MapServer