### PR TITLE
ENH: expose query_name in source

### DIFF
--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -41,13 +41,14 @@ def add_basemap(
         it is calculated automatically. Ignored if `source` is a local file.
     source : xyzservices.TileProvider object or str
         [Optional. Default: Stamen Terrain web tiles]
-        The tile source: web tile provider or path to local file. The web tile
-        provider can be in the form of a :class:`xyzservices.TileProvider` object or a
-        URL. The placeholders for the XYZ in the URL need to be `{x}`, `{y}`,
-        `{z}`, respectively. For local file paths, the file is read with
-        `rasterio` and all bands are loaded into the basemap.
-        IMPORTANT: tiles are assumed to be in the Spherical Mercator
-        projection (EPSG:3857), unless the `crs` keyword is specified.
+        The tile source: web tile provider, a valid input for a query of a
+        :class:`xyzservices.TileProvider` by a name from ``xyzservices.providers`` or
+        path to local file. The web tile provider can be in the form of a
+        :class:`xyzservices.TileProvider` object or a URL. The placeholders for the XYZ
+        in the URL need to be `{x}`, `{y}`, `{z}`, respectively. For local file paths,
+        the file is read with `rasterio` and all bands are loaded into the basemap.
+        IMPORTANT: tiles are assumed to be in the Spherical Mercator projection
+        (EPSG:3857), unless the `crs` keyword is specified.
     interpolation : str
         [Optional. Default='bilinear'] Interpolation algorithm to be passed
         to `imshow`. See `matplotlib.pyplot.imshow` for further details.
@@ -104,6 +105,13 @@ def add_basemap(
 
     """
     xmin, xmax, ymin, ymax = ax.axis()
+
+    if isinstance(source, str):
+        try:
+            source = providers.query_name(source)
+        except ValueError:
+            pass
+
     # If web source
     if (
         source is None
@@ -125,9 +133,9 @@ def add_basemap(
         if crs is not None:
             image, extent = warp_tiles(image, extent, t_crs=crs, resampling=resampling)
         # Check if overlay
-        if _is_overlay(source) and 'zorder' not in extra_imshow_args:
+        if _is_overlay(source) and "zorder" not in extra_imshow_args:
             # If zorder was not set then make it 9 otherwise leave it
-            extra_imshow_args['zorder'] = 9
+            extra_imshow_args["zorder"] = 9
     # If local source
     else:
         import rasterio as rio
@@ -207,6 +215,7 @@ def _reproj_bb(left, right, bottom, top, s_crs, t_crs):
     n_l, n_b, n_r, n_t = transform_bounds(s_crs, t_crs, left, bottom, right, top)
     return n_l, n_r, n_b, n_t
 
+
 def _is_overlay(source):
     """
     Check if the identified source is an overlay (partially transparent) layer.
@@ -228,22 +237,23 @@ def _is_overlay(source):
     """
     if not isinstance(source, dict):
         return False
-    if source.get('opacity', 1.0) < 1.0:
+    if source.get("opacity", 1.0) < 1.0:
         return True
     overlayPatterns = [
-        '^(OpenWeatherMap|OpenSeaMap)',
-        'OpenMapSurfer.(Hybrid|AdminBounds|ContourLines|Hillshade|ElementsAtRisk)',
-        'Stamen.Toner(Hybrid|Lines|Labels)',
-        'CartoDB.(Positron|DarkMatter|Voyager)OnlyLabels',
-        'Hydda.RoadsAndLabels',
-        '^JusticeMap',
-        'OpenPtMap',
-        'OpenRailwayMap',
-        'OpenFireMap',
-        'SafeCast'
+        "^(OpenWeatherMap|OpenSeaMap)",
+        "OpenMapSurfer.(Hybrid|AdminBounds|ContourLines|Hillshade|ElementsAtRisk)",
+        "Stamen.Toner(Hybrid|Lines|Labels)",
+        "CartoDB.(Positron|DarkMatter|Voyager)OnlyLabels",
+        "Hydda.RoadsAndLabels",
+        "^JusticeMap",
+        "OpenPtMap",
+        "OpenRailwayMap",
+        "OpenFireMap",
+        "SafeCast",
     ]
     import re
-    return bool(re.match('(' + '|'.join(overlayPatterns) + ')', source.get('name', '')))
+
+    return bool(re.match("(" + "|".join(overlayPatterns) + ")", source.get("name", "")))
 
 
 def add_attribution(ax, text, font_size=ATTRIBUTION_SIZE, **kwargs):

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -320,6 +320,33 @@ def test_add_basemap_local_source():
     assert_array_almost_equal(ax.images[0].get_array().mean(), 196.670225)
 
 
+def test_add_basemap_query():
+    # Plot boulder bbox as in test_place
+    x1, x2, y1, y2 = [
+        -11740727.544603072,
+        -11701591.786121061,
+        4852834.0517692715,
+        4891969.810251278,
+    ]
+
+    # Test web basemap
+    fig, ax = matplotlib.pyplot.subplots(1)
+    ax.set_xlim(x1, x2)
+    ax.set_ylim(y1, y2)
+    ctx.add_basemap(ax, zoom=10, source="stamen toner")
+
+    # ensure add_basemap did not change the axis limits of ax
+    ax_extent = (x1, x2, y1, y2)
+    assert ax.axis() == ax_extent
+
+    assert ax.images[0].get_array().sum() == 65119134
+    assert ax.images[0].get_array().shape == (256, 256, 4)
+    assert_array_almost_equal(
+        ax.images[0].get_array()[:, :, :3].mean(), 246.21304321289062
+    )
+    assert_array_almost_equal(ax.images[0].get_array().mean(), 248.40978240966797)
+
+
 @pytest.mark.network
 def test_add_basemap_full_read():
     ## Full read
@@ -419,7 +446,6 @@ def test_add_basemap_warping_local():
 
     assert ax.images[0].get_array().sum() == 678981558
     assert_array_almost_equal(ax.images[0].get_array().mean(), 200.939189)
-
 
 
 @pytest.mark.network

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -320,6 +320,7 @@ def test_add_basemap_local_source():
     assert_array_almost_equal(ax.images[0].get_array().mean(), 196.670225)
 
 
+@pytest.mark.network
 def test_add_basemap_query():
     # Plot boulder bbox as in test_place
     x1, x2, y1, y2 = [


### PR DESCRIPTION
Enabling passing a string from `source` to `query_name` to fetch the `TileProvider` in a more flexible way as we have in explore in GeoPandas.

Closes #190