### PR TITLE
Fix bug in auto computation of zoom levels

### DIFF
--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -531,7 +531,7 @@ def _calculate_zoom(w, s, e, n):
     # Calculate the zoom
     zoom_lon = np.ceil(np.log2(360 * 2.0 / lon_length))
     zoom_lat = np.ceil(np.log2(360 * 2.0 / lat_length))
-    zoom = np.max([zoom_lon, zoom_lat])
+    zoom = np.min([zoom_lon, zoom_lat])
     return int(zoom)
 
 

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -398,13 +398,13 @@ def test_add_basemap_auto_zoom():
         4891969.810251278,
     )
     assert_array_almost_equal(ax_extent, ax.images[0].get_extent())
-    assert ax.images[0].get_array()[:, :, :3].sum() == 563185119
-    assert ax.images[0].get_array().sum() == 830571999
-    assert ax.images[0].get_array().shape == (1024, 1024, 4)
+    assert ax.images[0].get_array()[:, :, :3].sum() == 141378723
+    assert ax.images[0].get_array().sum() == 208225443
+    assert ax.images[0].get_array().shape == (512, 512, 4)
     assert_array_almost_equal(
-        ax.images[0].get_array()[:, :, :3].mean(), 179.03172779083252
+        ax.images[0].get_array()[:, :, :3].mean(), 179.772343
     )
-    assert_array_almost_equal(ax.images[0].get_array().mean(), 198.023796)
+    assert_array_almost_equal(ax.images[0].get_array().mean(), 198.579257)
 
 
 @pytest.mark.network


### PR DESCRIPTION
For maps with large aspect ratio, contextily downloads tiles as if the map was as small as the smallest dimension. It should base the zoom level on the dimension that's a larger extent.

I discovered this bug when my server died attempting to render the following blue line on a map:
https://sondemaps.lectrobox.com/seattle/2023/4/13-17-47.64048--123.95468.jpg

This script has run fine for months, but in today's dataset the blue line coincidentally was almost perfectly horizontal. Therefore, the latitude extent of the map was very small, and because contextily uses the max of the two zoom levels, it attempted to download over a million zoomlevel 19 tiles from OSM.

