### PR TITLE
Added support for parallel tile downloads and control of cache

### DIFF
--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -232,7 +232,7 @@ def bounds2img(
     tiles = list(mt.tiles(w, s, e, n, [zoom]))
     tile_urls = [provider.build_url(x=tile.x, y=tile.y, z=tile.z) for tile in tiles]
     arrays = \
-        Parallel(n_jobs=num_parallel_tile_downloads, prefer="threads")(
+        Parallel(n_jobs=num_parallel_tile_downloads)(
             delayed(_fetch_tile)(tile_url, wait, max_retries) for tile_url in tile_urls)
     merged, extent = _merge_tiles(tiles, arrays)
     # lon/lat extent --> Spheric Mercator

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -70,7 +70,7 @@ def test_bounds2raster():
     assert_array_almost_equal(list(rtr.bounds), rtr_bounds)
 
 
-@pytest.mark.parametrize("n_connections", [0, 1, 16, 33])
+@pytest.mark.parametrize("n_connections", [0, 1, 16])
 @pytest.mark.network
 def test_bounds2img(n_connections):
     w, s, e, n = (
@@ -95,10 +95,6 @@ def test_bounds2img(n_connections):
     elif n_connections == 0:  # no connections should raise an error
         with pytest.raises(ValueError):
             img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True, n_connections=n_connections)
-    elif n_connections == 33:  # too many connections should raise an error
-        with pytest.raises(ValueError):
-            img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True, n_connections=n_connections,
-                                      max_connections=n_connections-1)
 
 
 @pytest.mark.network

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -70,26 +70,31 @@ def test_bounds2raster():
     assert_array_almost_equal(list(rtr.bounds), rtr_bounds)
 
 
+@pytest.mark.parametrize("n_connections", [0, 1, 16, 33])
 @pytest.mark.network
-def test_bounds2img():
+def test_bounds2img(n_connections):
     w, s, e, n = (
         -106.6495132446289,
         25.845197677612305,
         -93.50721740722656,
         36.49387741088867,
     )
-    img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True)
-    solu = (
-        -12523442.714243276,
-        -10018754.171394622,
-        2504688.5428486555,
-        5009377.085697309,
-    )
-    for i, j in zip(ext, solu):
-        assert round(i - j, TOL) == 0
-    assert img[100, 100, :].tolist() == [230, 229, 188, 255]
-    assert img[100, 200, :].tolist() == [156, 180, 131, 255]
-    assert img[200, 100, :].tolist() == [230, 225, 189, 255]
+    if n_connections in [1, 16]:  # accepted number of connections
+        img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True, n_connections=n_connections)
+        solu = (
+            -12523442.714243276,
+            -10018754.171394622,
+            2504688.5428486555,
+            5009377.085697309,
+        )
+        for i, j in zip(ext, solu):
+            assert round(i - j, TOL) == 0
+        assert img[100, 100, :].tolist() == [230, 229, 188, 255]
+        assert img[100, 200, :].tolist() == [156, 180, 131, 255]
+        assert img[200, 100, :].tolist() == [230, 225, 189, 255]
+    else:  # too few/many connections should raise an error
+        with pytest.raises(ValueError):
+            img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True, n_connections=n_connections)
 
 
 @pytest.mark.network

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -79,7 +79,7 @@ def test_bounds2img(n_connections):
         -93.50721740722656,
         36.49387741088867,
     )
-    if n_connections in [1, 16]:  # accepted number of connections
+    if n_connections in [1, 16]:  # valid number of connections (test single and multiple connections)
         img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True, n_connections=n_connections)
         solu = (
             -12523442.714243276,
@@ -92,9 +92,13 @@ def test_bounds2img(n_connections):
         assert img[100, 100, :].tolist() == [230, 229, 188, 255]
         assert img[100, 200, :].tolist() == [156, 180, 131, 255]
         assert img[200, 100, :].tolist() == [230, 225, 189, 255]
-    else:  # too few/many connections should raise an error
+    elif n_connections == 0:  # no connections should raise an error
         with pytest.raises(ValueError):
             img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True, n_connections=n_connections)
+    elif n_connections == 33:  # too many connections should raise an error
+        with pytest.raises(ValueError):
+            img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True, n_connections=n_connections,
+                                      max_connections=n_connections-1)
 
 
 @pytest.mark.network


### PR DESCRIPTION
This pull request is a fix for https://github.com/geopandas/contextily/issues/215 

I have added support for parallel tile downloads in the bounds2raster and bounds2img functions. It gives some quite significant speed improvements, with minor changes to the code. I wasn't sure were to put `max_num_parallel_tile_downloads = 32`, so for now it is on line 227 in `tile.py` (i.e., inside the bounds2img function code). Let me know if there is anything you would like to have changed. 

Thanks for an awesome package btw.! :smiley: 