### PR TITLE
Fix inconsistency in import alias

### DIFF
--- a/contextily/place.py
+++ b/contextily/place.py
@@ -177,7 +177,7 @@ class Place(object):
         Examples
         --------
 
-        >>> lvl = ctx.Place('Liverpool')
+        >>> lvl = cx.Place('Liverpool')
         >>> lvl.plot()
 
         """

--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -82,7 +82,7 @@ def add_basemap(
     --------
 
     >>> import geopandas
-    >>> import contextily as ctx
+    >>> import contextily as cx
     >>> db = geopandas.read_file(ps.examples.get_path('virginia.shp'))
 
     Ensure the data is in Spherical Mercator:
@@ -92,15 +92,15 @@ def add_basemap(
     Add a web basemap:
 
     >>> ax = db.plot(alpha=0.5, color='k', figsize=(6, 6))
-    >>> ctx.add_basemap(ax, source=url)
+    >>> cx.add_basemap(ax, source=url)
     >>> plt.show()
 
     Or download a basemap to a local file and then plot it:
 
     >>> source = 'virginia.tiff'
-    >>> _ = ctx.bounds2raster(*db.total_bounds, zoom=6, source=source)
+    >>> _ = cx.bounds2raster(*db.total_bounds, zoom=6, source=source)
     >>> ax = db.plot(alpha=0.5, color='k', figsize=(6, 6))
-    >>> ctx.add_basemap(ax, source=source)
+    >>> cx.add_basemap(ax, source=source)
     >>> plt.show()
 
     """

--- a/examples/plot_map.py
+++ b/examples/plot_map.py
@@ -18,9 +18,9 @@ image of the place.
 """
 import numpy as np
 import matplotlib.pyplot as plt
-import contextily as ctx
+import contextily as cx
 
-loc = ctx.Place("boulder", zoom_adjust=0)  # zoom_adjust modifies the auto-zoom
+loc = cx.Place("boulder", zoom_adjust=0)  # zoom_adjust modifies the auto-zoom
 
 # Print some metadata
 for attr in ["w", "s", "e", "n", "place", "zoom", "n_tiles"]:
@@ -30,14 +30,14 @@ for attr in ["w", "s", "e", "n", "place", "zoom", "n_tiles"]:
 im1 = loc.im
 
 fig, axs = plt.subplots(1, 3, figsize=(15, 5))
-ctx.plot_map(loc, ax=axs[0])
+cx.plot_map(loc, ax=axs[0])
 
 ###############################################################################
 # The zoom level will be chosen for you by default, though you can specify
 # this manually as well:
 
-loc2 = ctx.Place("boulder", zoom=11)
-ctx.plot_map(loc2, ax=axs[1])
+loc2 = cx.Place("boulder", zoom=11)
+cx.plot_map(loc2, ax=axs[1])
 
 ###############################################################################
 # Downloading tiles from bounds
@@ -46,7 +46,7 @@ ctx.plot_map(loc2, ax=axs[1])
 # You can also grab tile information directly from a bounding box + zoom level.
 # This is demoed below:
 
-im2, bbox = ctx.bounds2img(loc.w, loc.s, loc.e, loc.n, zoom=loc.zoom, ll=True)
-ctx.plot_map(im2, bbox, ax=axs[2], title="Boulder, CO")
+im2, bbox = cx.bounds2img(loc.w, loc.s, loc.e, loc.n, zoom=loc.zoom, ll=True)
+cx.plot_map(im2, bbox, ax=axs[2], title="Boulder, CO")
 
 plt.show()

--- a/notebooks/working_with_local_files.ipynb
+++ b/notebooks/working_with_local_files.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "%matplotlib inline\n",
     "\n",
-    "import contextily as ctx\n",
+    "import contextily as cx\n",
     "import geopandas\n",
     "import rasterio\n",
     "from rasterio.plot import show as rioshow\n",
@@ -90,7 +90,7 @@
    ],
    "source": [
     "ax = cliwoc.plot(linewidth=0.01, alpha=0.5, color=\"k\")\n",
-    "ctx.add_basemap(ax, \n",
+    "cx.add_basemap(ax, \n",
     "                crs=cliwoc.crs,\n",
     "               )"
    ]
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img, ext = ctx.bounds2raster(west, \n",
+    "img, ext = cx.bounds2raster(west, \n",
     "                             south, \n",
     "                             east, \n",
     "                             north, \n",
@@ -227,7 +227,7 @@
     }
    ],
    "source": [
-    "cape_town = ctx.Place(\"Cape Town\", source=ctx.providers.OpenStreetMap.Mapnik)\n",
+    "cape_town = cx.Place(\"Cape Town\", source=cx.providers.OpenStreetMap.Mapnik)\n",
     "cape_town.plot()"
    ]
   },
@@ -244,7 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cape_town = ctx.Place(\"Cape Town\", source=ctx.providers.OpenStreetMap.Mapnik, path=\"cape_town.tif\")"
+    "cape_town = cx.Place(\"Cape Town\", source=cx.providers.OpenStreetMap.Mapnik, path=\"cape_town.tif\")"
    ]
   },
   {
@@ -454,7 +454,7 @@
    ],
    "source": [
     "ax = cliwoc_cape_town.plot(linewidth=0.05, color=\"k\")\n",
-    "ctx.add_basemap(ax, \n",
+    "cx.add_basemap(ax, \n",
     "                crs=cliwoc_cape_town.crs, \n",
     "                source=\"cape_town.tif\"\n",
     "               )"
@@ -487,7 +487,7 @@
    ],
    "source": [
     "ax = cliwoc_cape_town.plot(linewidth=0.05, color=\"k\")\n",
-    "ctx.add_basemap(ax, \n",
+    "cx.add_basemap(ax, \n",
     "                crs=cliwoc_cape_town.crs, \n",
     "                source=\"cape_town.tif\",\n",
     "                alpha=0.5\n",
@@ -521,7 +521,7 @@
    ],
    "source": [
     "ax = cliwoc_cape_town_buffer.plot(linewidth=1, color=\"k\")\n",
-    "ctx.add_basemap(ax, \n",
+    "cx.add_basemap(ax, \n",
     "                crs=cliwoc_cape_town.crs, \n",
     "                source=\"cape_town.tif\"\n",
     "               )"
@@ -552,7 +552,7 @@
    ],
    "source": [
     "ax = cliwoc_cape_town_buffer.plot(linewidth=1, color=\"k\")\n",
-    "ctx.add_basemap(ax, \n",
+    "cx.add_basemap(ax, \n",
     "                crs=cliwoc_cape_town.crs, \n",
     "                source=\"cape_town.tif\",\n",
     "                reset_extent=False\n",

--- a/tests/test_cx.py
+++ b/tests/test_cx.py
@@ -1,7 +1,7 @@
 import matplotlib
 
 matplotlib.use("agg")  # To prevent plots from using display
-import contextily as ctx
+import contextily as cx
 import os
 import numpy as np
 import mercantile as mt
@@ -26,7 +26,7 @@ def test_bounds2raster():
         -93.50721740722656,
         36.49387741088867,
     )
-    _ = ctx.bounds2raster(w, s, e, n, "test.tif", zoom=4, ll=True)
+    _ = cx.bounds2raster(w, s, e, n, "test.tif", zoom=4, ll=True)
     rtr = rio.open("test.tif")
     img = np.array([band for band in rtr.read()]).transpose(1, 2, 0)
     solu = (
@@ -52,7 +52,7 @@ def test_bounds2raster():
         6.15665815595878,
         51.47502370869813,
     )
-    img, ext = ctx.bounds2raster(w, s, e, n, "test2.tif", zoom=7, ll=True)
+    img, ext = cx.bounds2raster(w, s, e, n, "test2.tif", zoom=7, ll=True)
     rtr = rio.open("test2.tif")
     rimg = np.array([band for band in rtr.read()]).transpose(1, 2, 0)
     assert rimg.shape == img.shape
@@ -83,7 +83,7 @@ def test_bounds2img(n_connections):
         1,
         16,
     ]:  # valid number of connections (test single and multiple connections)
-        img, ext = ctx.bounds2img(
+        img, ext = cx.bounds2img(
             w, s, e, n, zoom=4, ll=True, n_connections=n_connections
         )
         solu = (
@@ -99,7 +99,7 @@ def test_bounds2img(n_connections):
         assert img[200, 100, :].tolist() == [247, 246, 241, 255]
     elif n_connections == 0:  # no connections should raise an error
         with pytest.raises(ValueError):
-            img, ext = ctx.bounds2img(
+            img, ext = cx.bounds2img(
                 w, s, e, n, zoom=4, ll=True, n_connections=n_connections
             )
 
@@ -112,8 +112,8 @@ def test_warp_tiles():
         -93.50721740722656,
         36.49387741088867,
     )
-    img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True)
-    wimg, wext = ctx.warp_tiles(img, ext)
+    img, ext = cx.bounds2img(w, s, e, n, zoom=4, ll=True)
+    wimg, wext = cx.warp_tiles(img, ext)
     assert_array_almost_equal(
         np.array(wext),
         np.array(
@@ -138,10 +138,10 @@ def test_warp_img_transform():
         -93.50721740722656,
         36.49387741088867,
     )
-    _ = ctx.bounds2raster(w, s, e, n, "test.tif", zoom=4, ll=True)
+    _ = cx.bounds2raster(w, s, e, n, "test.tif", zoom=4, ll=True)
     rtr = rio.open("test.tif")
     img = np.array([band for band in rtr.read()])
-    wimg, _ = ctx.warp_img_transform(img, rtr.transform, rtr.crs, "epsg:4326")
+    wimg, _ = cx.warp_img_transform(img, rtr.transform, rtr.crs, "epsg:4326")
     assert wimg[:, 100, 100].tolist() == [247, 246, 241, 255]
     assert wimg[:, 100, 200].tolist() == [246, 246, 241, 255]
     assert wimg[:, 20, 120].tolist() == [139, 128, 148, 255]
@@ -156,7 +156,7 @@ def test_howmany():
     )
     zoom = 7
     expected = 25
-    got = ctx.howmany(w, s, e, n, zoom=zoom, verbose=False, ll=True)
+    got = cx.howmany(w, s, e, n, zoom=zoom, verbose=False, ll=True)
     assert got == expected
 
 
@@ -169,9 +169,9 @@ def test_ll2wdw():
         36.49387741088867,
     )
     hou = (-10676650.69219051, 3441477.046670125, -10576977.7804825, 3523606.146650609)
-    _ = ctx.bounds2raster(w, s, e, n, "test.tif", zoom=4, ll=True)
+    _ = cx.bounds2raster(w, s, e, n, "test.tif", zoom=4, ll=True)
     rtr = rio.open("test.tif")
-    wdw = ctx.tile.bb2wdw(hou, rtr)
+    wdw = cx.tile.bb2wdw(hou, rtr)
     assert wdw == ((152, 161), (189, 199))
 
 
@@ -182,8 +182,8 @@ def test__sm2ll():
         -93.50721740722656,
         36.49387741088867,
     )
-    minX, minY = ctx.tile._sm2ll(w, s)
-    maxX, maxY = ctx.tile._sm2ll(e, n)
+    minX, minY = cx.tile._sm2ll(w, s)
+    maxX, maxY = cx.tile._sm2ll(e, n)
     nw, ns = mt.xy(minX, minY)
     ne, nn = mt.xy(maxX, maxY)
     assert round(nw - w, TOL) == 0
@@ -206,20 +206,20 @@ def test_validate_zoom():
 
     # automatically inferred -> set to known max but warn
     with pytest.warns(UserWarning, match="inferred zoom level"):
-        ctx.bounds2img(w, s, e, n)
+        cx.bounds2img(w, s, e, n)
 
     # specify manually -> raise an error
     with pytest.raises(ValueError):
-        ctx.bounds2img(w, s, e, n, zoom=23)
+        cx.bounds2img(w, s, e, n, zoom=23)
 
     # with specific string url (not dict) -> error when specified
     url = "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
     with pytest.raises(ValueError):
-        ctx.bounds2img(w, s, e, n, zoom=33, source=url)
+        cx.bounds2img(w, s, e, n, zoom=33, source=url)
 
     # but also when inferred (no max zoom know to set to)
     with pytest.raises(ValueError):
-        ctx.bounds2img(w, s, e, n, source=url)
+        cx.bounds2img(w, s, e, n, source=url)
 
 
 # Place
@@ -235,7 +235,7 @@ def test_place():
         4891969.810251278,
     ]
     expected_zoom = 10
-    loc = ctx.Place(SEARCH, zoom_adjust=ADJUST)
+    loc = cx.Place(SEARCH, zoom_adjust=ADJUST)
     assert loc.im.shape == (256, 256, 4)
     loc  # Make sure repr works
 
@@ -245,7 +245,7 @@ def test_place():
     assert_array_almost_equal(loc.bbox_map, expected_bbox_map)
     assert loc.zoom == expected_zoom
 
-    loc = ctx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
+    loc = cx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
     assert os.path.exists("./test2.tif")
 
     # .plot() method
@@ -260,17 +260,17 @@ def test_place():
 @pytest.mark.network
 def test_plot_map():
     # Place as a search
-    loc = ctx.Place(SEARCH, zoom_adjust=ADJUST)
+    loc = cx.Place(SEARCH, zoom_adjust=ADJUST)
     w, e, s, n = loc.bbox_map
-    ax = ctx.plot_map(loc)
+    ax = cx.plot_map(loc)
 
     assert ax.get_title() == loc.place
-    ax = ctx.plot_map(loc.im, loc.bbox)
+    ax = cx.plot_map(loc.im, loc.bbox)
     assert_array_almost_equal(loc.bbox, ax.images[0].get_extent())
 
     # Place as an image
-    img, ext = ctx.bounds2img(w, s, e, n, zoom=10)
-    ax = ctx.plot_map(img, ext)
+    img, ext = cx.bounds2img(w, s, e, n, zoom=10)
+    ax = cx.plot_map(img, ext)
     assert_array_almost_equal(ext, ax.images[0].get_extent())
 
 
@@ -291,7 +291,7 @@ def test_add_basemap():
     fig, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    ctx.add_basemap(ax, zoom=10)
+    cx.add_basemap(ax, zoom=10)
 
     # ensure add_basemap did not change the axis limits of ax
     ax_extent = (x1, x2, y1, y2)
@@ -321,8 +321,8 @@ def test_add_basemap_local_source():
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(subset[0], subset[1])
     ax.set_ylim(subset[2], subset[3])
-    _ = ctx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
-    ctx.add_basemap(ax, source="./test2.tif", reset_extent=True)
+    _ = cx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
+    cx.add_basemap(ax, source="./test2.tif", reset_extent=True)
 
     assert_array_almost_equal(subset, ax.images[0].get_extent())
     assert ax.images[0].get_array().sum() == pytest.approx(13758065, rel=0.1)
@@ -348,7 +348,7 @@ def test_add_basemap_query():
     fig, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    ctx.add_basemap(ax, zoom=10, source="cartodb positron")
+    cx.add_basemap(ax, zoom=10, source="cartodb positron")
 
     # ensure add_basemap did not change the axis limits of ax
     ax_extent = (x1, x2, y1, y2)
@@ -372,8 +372,8 @@ def test_add_basemap_full_read():
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    loc = ctx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
-    ctx.add_basemap(ax, source="./test2.tif", reset_extent=False)
+    loc = cx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
+    cx.add_basemap(ax, source="./test2.tif", reset_extent=False)
 
     raster_extent = (
         -11740803.981631,
@@ -403,7 +403,7 @@ def test_add_basemap_auto_zoom():
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    ctx.add_basemap(ax, zoom="auto")
+    cx.add_basemap(ax, zoom="auto")
 
     ax_extent = (
         -11740727.544603072,
@@ -429,7 +429,7 @@ def test_add_basemap_warping():
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    ctx.add_basemap(ax, crs="epsg:4326", attribution=None)
+    cx.add_basemap(ax, crs="epsg:4326", attribution=None)
     assert ax.get_xlim() == (x1, x2)
     assert ax.get_ylim() == (y1, y2)
     assert ax.images[0].get_array()[:, :, :3].sum() == pytest.approx(811443707, rel=0.1)
@@ -445,11 +445,11 @@ def test_add_basemap_warping_local():
     # Test local source warping
     x1, x2 = -105.5, -105.00
     y1, y2 = 39.56, 40.13
-    _ = ctx.bounds2raster(x1, y1, x2, y2, "./test2.tif", ll=True)
+    _ = cx.bounds2raster(x1, y1, x2, y2, "./test2.tif", ll=True)
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    ctx.add_basemap(ax, source="./test2.tif", crs="epsg:4326", attribution=None)
+    cx.add_basemap(ax, source="./test2.tif", crs="epsg:4326", attribution=None)
     assert ax.get_xlim() == (x1, x2)
     assert ax.get_ylim() == (y1, y2)
 
@@ -476,8 +476,8 @@ def test_add_basemap_overlay():
     ax.set_ylim(y1, y2)
 
     # Draw two layers, the 2nd of which is an overlay.
-    ctx.add_basemap(ax, zoom=10)
-    ctx.add_basemap(ax, zoom=10, source=ctx.providers.CartoDB.PositronOnlyLabels)
+    cx.add_basemap(ax, zoom=10)
+    cx.add_basemap(ax, zoom=10, source=cx.providers.CartoDB.PositronOnlyLabels)
 
     # ensure add_basemap did not change the axis limits of ax
     ax_extent = (x1, x2, y1, y2)
@@ -504,8 +504,8 @@ def test_add_basemap_overlay():
     ax.set_ylim(y1, y2)
 
     # Draw two layers, the 1st of which is an overlay.
-    ctx.add_basemap(ax, zoom=10, source=ctx.providers.CartoDB.PositronOnlyLabels)
-    ctx.add_basemap(ax, zoom=10)
+    cx.add_basemap(ax, zoom=10, source=cx.providers.CartoDB.PositronOnlyLabels)
+    cx.add_basemap(ax, zoom=10)
 
     # check that z-order of overlay is higher than that of base layer
     assert ax.images[0].zorder > ax.images[1].zorder
@@ -527,40 +527,40 @@ def test_basemap_attribution():
     # default provider and attribution
     fig, ax = matplotlib.pyplot.subplots()
     ax.axis(extent)
-    ctx.add_basemap(ax)
+    cx.add_basemap(ax)
     (txt,) = get_attr(ax)
-    assert txt.get_text() == ctx.providers.OpenStreetMap.HOT["attribution"]
+    assert txt.get_text() == cx.providers.OpenStreetMap.HOT["attribution"]
 
     # override attribution
     fig, ax = matplotlib.pyplot.subplots()
     ax.axis(extent)
-    ctx.add_basemap(ax, attribution="custom text")
+    cx.add_basemap(ax, attribution="custom text")
     (txt,) = get_attr(ax)
     assert txt.get_text() == "custom text"
 
     # disable attribution
     fig, ax = matplotlib.pyplot.subplots()
     ax.axis(extent)
-    ctx.add_basemap(ax, attribution=False)
+    cx.add_basemap(ax, attribution=False)
     assert len(get_attr(ax)) == 0
 
     # specified provider
     fig, ax = matplotlib.pyplot.subplots()
     ax.axis(extent)
-    ctx.add_basemap(ax, source=ctx.providers.OpenStreetMap.Mapnik)
+    cx.add_basemap(ax, source=cx.providers.OpenStreetMap.Mapnik)
     (txt,) = get_attr(ax)
-    assert txt.get_text() == ctx.providers.OpenStreetMap.Mapnik["attribution"]
+    assert txt.get_text() == cx.providers.OpenStreetMap.Mapnik["attribution"]
 
 
 def test_attribution():
     fig, ax = matplotlib.pyplot.subplots(1)
-    txt = ctx.add_attribution(ax, "Test")
+    txt = cx.add_attribution(ax, "Test")
     assert isinstance(txt, matplotlib.text.Text)
     assert txt.get_text() == "Test"
 
     # test passthrough font size and kwargs
     fig, ax = matplotlib.pyplot.subplots(1)
-    txt = ctx.add_attribution(ax, "Test", font_size=15, fontfamily="monospace")
+    txt = cx.add_attribution(ax, "Test", font_size=15, fontfamily="monospace")
     assert txt.get_size() == 15
     assert txt.get_fontfamily() == ["monospace"]
 
@@ -569,10 +569,10 @@ def test_attribution():
 def test_set_cache_dir(tmpdir):
     # set cache directory manually
     path = str(tmpdir.mkdir("cache"))
-    ctx.set_cache_dir(path)
+    cx.set_cache_dir(path)
 
     # then check that plotting still works
     extent = (-11945319, -10336026, 2910477, 4438236)
     fig, ax = matplotlib.pyplot.subplots()
     ax.axis(extent)
-    ctx.add_basemap(ax)
+    cx.add_basemap(ax)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,5 +1,5 @@
 import xyzservices
-import contextily as ctx
+import contextily as cx
 
 import pytest
 from numpy.testing import assert_allclose
@@ -15,32 +15,32 @@ def test_providers():
         36.49387741088867,
     )
     for provider in [
-        ctx.providers.OpenStreetMap.Mapnik,
-        ctx.providers.Stamen.Toner,
-        ctx.providers.NASAGIBS.ViirsEarthAtNight2012,
+        cx.providers.OpenStreetMap.Mapnik,
+        cx.providers.Stamen.Toner,
+        cx.providers.NASAGIBS.ViirsEarthAtNight2012,
     ]:
-        ctx.bounds2img(w, s, e, n, 4, source=provider, ll=True)
+        cx.bounds2img(w, s, e, n, 4, source=provider, ll=True)
 
 
 def test_providers_callable():
     # only testing the callable functionality to override a keyword, as we
     # cannot test the actual providers that need an API key
-    updated_provider = ctx.providers.GeoportailFrance.plan(apikey="mykey")
+    updated_provider = cx.providers.GeoportailFrance.plan(apikey="mykey")
     assert isinstance(updated_provider, xyzservices.TileProvider)
     assert "url" in updated_provider
     assert updated_provider["apikey"] == "mykey"
     # check that original provider dict is not modified
-    assert ctx.providers.GeoportailFrance.plan["apikey"] == "essentiels"
+    assert cx.providers.GeoportailFrance.plan["apikey"] == "essentiels"
 
 
 def test_invalid_provider():
     w, s, e, n = (-106.649, 25.845, -93.507, 36.494)
     with pytest.raises(ValueError, match="The 'url' dict should at least contain"):
-        ctx.bounds2img(w, s, e, n, 4, source={"missing": "url"}, ll=True)
+        cx.bounds2img(w, s, e, n, 4, source={"missing": "url"}, ll=True)
 
 
 def test_provider_attribute_access():
-    provider = ctx.providers.OpenStreetMap.Mapnik
+    provider = cx.providers.OpenStreetMap.Mapnik
     assert provider.name == "OpenStreetMap.Mapnik"
     with pytest.raises(AttributeError):
         provider.non_existing_key


### PR DESCRIPTION
This PR addresses the inconsistent import alias, instead of contextily being imported as `ctx` or `cx` it is now only imported as `cx`. This is in line with the [GeoPandas documentation](https://geopandas.org/en/stable/gallery/plotting_basemap_background.html).