### PR TITLE
expand retryer to include image reading

### DIFF
--- a/tests/test_cx.py
+++ b/tests/test_cx.py
@@ -127,7 +127,7 @@ def test_warp_tiles():
     )
     assert wimg[100, 100, :].tolist() == [247, 246, 241, 255]
     assert wimg[100, 200, :].tolist() == [246, 246, 241, 255]
-    assert wimg[20, 120, :].tolist() == [139, 128, 148, 255]
+    assert wimg[20, 120, :].tolist() == [139, 128, 149, 255]
 
 
 @pytest.mark.network
@@ -144,7 +144,7 @@ def test_warp_img_transform():
     wimg, _ = cx.warp_img_transform(img, rtr.transform, rtr.crs, "epsg:4326")
     assert wimg[:, 100, 100].tolist() == [247, 246, 241, 255]
     assert wimg[:, 100, 200].tolist() == [246, 246, 241, 255]
-    assert wimg[:, 20, 120].tolist() == [139, 128, 148, 255]
+    assert wimg[:, 20, 120].tolist() == [139, 128, 149, 255]
 
 
 def test_howmany():


### PR DESCRIPTION
moving image opening to the retryer in hope that it could resolve rare occasions of `UnidentifiedImageError` popping up. Reported in https://github.com/networkx/networkx/issues/7301 and seen once in our CI ([here](https://github.com/geopandas/contextily/actions/runs/7909639251/job/21591004622)). I wasn't able to reproduce the issue locally in any form so I am not sure if it will fix it but it is the only thing I could think of.

To get a better control of retries, we should also probably expose  `wait`, `max_retries`, `n_connections` and `use_cache` on `add_basemap` level, not only in `bounds2img` but I'll do that separately.