### PR TITLE
Ignore rmtree errors for serverless environments

### DIFF
--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -58,7 +58,7 @@ def set_cache_dir(path):
 
 
 def _clear_cache():
-    shutil.rmtree(tmpdir)
+    shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 atexit.register(_clear_cache)


### PR DESCRIPTION
Using Contextily in a managed serverless environment removes the tmp directory before `atexit` fires, which results in the following error. Which, I wager means it can't find the indicated directory to delete. 

```
Traceback (most recent call last):
  File "/layers/google.python.pip/pip/lib/python3.11/site-packages/contextily/tile.py", line 61, in _clear_cache
    shutil.rmtree(tmpdir)
  File "/layers/google.python.runtime/python/lib/python3.11/shutil.py", line 742, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/layers/google.python.runtime/python/lib/python3.11/shutil.py", line 740, in rmtree
    orig_st = os.lstat(path, dir_fd=dir_fd) 
```

I can put our invocation behind a try-catch, or otherwise ignore this error, but an upstream patch would be preferable. 

Thanks!