### PR TITLE
TST: remove callable test

### DIFF
--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,8 +1,6 @@
-import xyzservices
 import contextily as cx
 
 import pytest
-from numpy.testing import assert_allclose
 
 
 @pytest.mark.network
@@ -19,18 +17,6 @@ def test_providers():
         cx.providers.NASAGIBS.ViirsEarthAtNight2012,
     ]:
         cx.bounds2img(w, s, e, n, 4, source=provider, ll=True)
-
-
-def test_providers_callable():
-    # only testing the callable functionality to override a keyword, as we
-    # cannot test the actual providers that need an API key
-    updated_provider = cx.providers.GeoportailFrance.plan(apikey="mykey")
-    assert isinstance(updated_provider, xyzservices.TileProvider)
-    assert "url" in updated_provider
-    assert updated_provider["apikey"] == "mykey"
-    # check that original provider dict is not modified
-    assert cx.providers.GeoportailFrance.plan["apikey"] == "essentiels"
-
 
 def test_invalid_provider():
     w, s, e, n = (-106.649, 25.845, -93.507, 36.494)


### PR DESCRIPTION
This is tested in xyzservices and just got out of sync. No need to duplicate.