### PR TITLE
improve stability of ctx.add_basemap()

### DIFF
--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -442,14 +442,15 @@ def _retryer(tile_url, wait, max_retries):
                 "Tile URL resulted in a 404 error. "
                 "Double-check your tile url:\n{}".format(tile_url)
             )
-        elif request.status_code == 104 or request.status_code == 200:
+        else:
             if max_retries > 0:
                 os.wait(wait)
                 max_retries -= 1
                 request = _retryer(tile_url, wait, max_retries)
             else:
-                raise requests.HTTPError("Connection reset by peer too many times.")
-
+                raise requests.HTTPError("Connection reset by peer too many times. "
+                                         f"Last message was: {request.status_code} "
+                                         f"Error: {request.reason} for url: {request.url}")
 
 
 def howmany(w, s, e, n, zoom, verbose=True, ll=False):


### PR DESCRIPTION
Fixes #247

Changed:
* made sure all `HTTPError`s are captured and retried
* included the last error/reason message when max_retries is reached

The code in this contribution catches all `HTTPError`s and therefore makes it impossible that the code continue with `None` in the `arrays` list. This used to cause varying errors related to `None`, depending on whether the first in the `arrays` list was `None` or not, or any of the others. By capturing all HTTPErrors, the code is redirected to retrying instead of that the `_retryer()` function returns None. After `max_retries` is reached, the user now gets a informative error message. The format of the message is based on what `request.raise_for_status()` would return.

The current code proves useful, these were the error messages during the manual tests:
- `HTTPError: Connection reset by peer too many times. Last message was: 502 Error: Bad Gateway for url: https://a.tile.openstreetmap.fr/hot/10/812/458.png`
- `500 Error` (forgot to copy this one when it occurred

@martinfleis could you review this PR?