### PR TITLE
BUG: do not change the aspect of the axis

### DIFF
--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -26,7 +26,7 @@ def add_basemap(
     crs=None,
     resampling=Resampling.bilinear,
     zoom_adjust=None,
-    **extra_imshow_args
+    **extra_imshow_args,
 ):
     """
     Add a (web/local) basemap to `ax`.
@@ -78,7 +78,7 @@ def add_basemap(
         `rasterio.enums.Resampling` method
     zoom_adjust : int or None
         [Optional. Default: None]
-        The amount to adjust a chosen zoom level if it is chosen automatically. 
+        The amount to adjust a chosen zoom level if it is chosen automatically.
         Values outside of -1 to 1 are not recommended as they can lead to slow execution.
     **extra_imshow_args :
         Other parameters to be passed to `imshow`.
@@ -132,7 +132,14 @@ def add_basemap(
             )
         # Download image
         image, extent = bounds2img(
-            left, bottom, right, top, zoom=zoom, source=source, ll=False, zoom_adjust=zoom_adjust
+            left,
+            bottom,
+            right,
+            top,
+            zoom=zoom,
+            source=source,
+            ll=False,
+            zoom_adjust=zoom_adjust,
         )
         # Warping
         if crs is not None:
@@ -190,8 +197,12 @@ def add_basemap(
     # Plotting
     if image.shape[2] == 1:
         image = image[:, :, 0]
-    img = ax.imshow(
-        image, extent=extent, interpolation=interpolation, **extra_imshow_args
+    _ = ax.imshow(
+        image,
+        extent=extent,
+        interpolation=interpolation,
+        aspect=ax.get_aspect(),  # GH251
+        **extra_imshow_args,
     )
 
     if reset_extent:

--- a/tests/test_cx.py
+++ b/tests/test_cx.py
@@ -660,3 +660,24 @@ def test_set_cache_dir(tmpdir):
     fig, ax = matplotlib.pyplot.subplots()
     ax.axis(extent)
     cx.add_basemap(ax)
+
+
+@pytest.mark.network
+def test_aspect():
+    """Test that contextily does not change set aspect"""
+    # Plot boulder bbox as in test_place
+    x1, x2, y1, y2 = [
+        -11740727.544603072,
+        -11701591.786121061,
+        4852834.0517692715,
+        4891969.810251278,
+    ]
+
+    # Test web basemap
+    fig, ax = matplotlib.pyplot.subplots(1)
+    ax.set_xlim(x1, x2)
+    ax.set_ylim(y1, y2)
+    ax.set_aspect(2)
+    cx.add_basemap(ax, zoom=10)
+
+    assert ax.get_aspect() == 2


### PR DESCRIPTION
Closes #251 

Using `aspect=ax.get_aspect()` fixes the behaviour reported in #251 and avoid changing the aspect of the axis if it is other than equal.

What I am not certain is whether we want to do this as it means that resulting pixels are not square, distorting the image. But that is ultimately a responsibility of a user and this way we give them a chance to affect the aspect as until now, we always enforce equal aspect.

The only relevant change is on line 204, the rest is linting.