### PR TITLE
test: Increase timeout and retries

### DIFF
--- a/tests/test_cx.py
+++ b/tests/test_cx.py
@@ -9,10 +9,11 @@ import pytest
 import rasterio as rio
 from contextily.tile import _calculate_zoom
 from numpy.testing import assert_array_almost_equal
-import pytest
 from unittest.mock import patch, MagicMock
 import io
 from PIL import Image
+import geopy
+
 
 TOL = 7
 SEARCH = "boulder"
@@ -32,16 +33,16 @@ def test_bounds2raster():
     _ = cx.bounds2raster(
         w, s, e, n, "test.tif", zoom=4, ll=True, source=cx.providers.CartoDB.Positron
     )
-    rtr = rio.open("test.tif")
-    img = np.array([band for band in rtr.read()]).transpose(1, 2, 0)
-    solu = (
-        -12528334.684053527,
-        2509580.5126589066,
-        -10023646.141204873,
-        5014269.05550756,
-    )
-    for i, j in zip(rtr.bounds, solu):
-        assert round(i - j, TOL) == 0
+    with rio.open("test.tif") as rtr:
+        img = np.array([band for band in rtr.read()]).transpose(1, 2, 0)
+        solu = (
+            -12528334.684053527,
+            2509580.5126589066,
+            -10023646.141204873,
+            5014269.05550756,
+        )
+        for i, j in zip(rtr.bounds, solu):
+            assert round(i - j, TOL) == 0
     # Check approximate pixel values instead of exact matches for robustness
     assert np.allclose(img[0, 100, :], [250, 250, 248, 255], atol=10)
     assert np.allclose(img[20, 120, :], [139, 153, 164, 255], atol=10)
@@ -61,21 +62,21 @@ def test_bounds2raster():
     img, ext = cx.bounds2raster(
         w, s, e, n, "test2.tif", zoom=7, ll=True, source=cx.providers.CartoDB.Positron
     )
-    rtr = rio.open("test2.tif")
-    rimg = np.array([band for band in rtr.read()]).transpose(1, 2, 0)
-    assert rimg.shape == img.shape
-    assert rimg.sum() == img.sum()
-    assert_array_almost_equal(rimg.mean(), img.mean())
-    assert_array_almost_equal(
-        ext, (0.0, 939258.2035682457, 6261721.35712164, 6887893.492833804)
-    )
-    rtr_bounds = [
-        -611.49622628141,
-        6262332.853347922,
-        938646.7073419644,
-        6888504.989060086,
-    ]
-    assert_array_almost_equal(list(rtr.bounds), rtr_bounds)
+    with rio.open("test2.tif") as rtr:
+        rimg = np.array([band for band in rtr.read()]).transpose(1, 2, 0)
+        assert rimg.shape == img.shape
+        assert rimg.sum() == img.sum()
+        assert_array_almost_equal(rimg.mean(), img.mean())
+        assert_array_almost_equal(
+            ext, (0.0, 939258.2035682457, 6261721.35712164, 6887893.492833804)
+        )
+        rtr_bounds = [
+            -611.49622628141,
+            6262332.853347922,
+            938646.7073419644,
+            6888504.989060086,
+        ]
+        assert_array_almost_equal(list(rtr.bounds), rtr_bounds)
 
 
 @pytest.mark.parametrize("n_connections", [0, 1, 16])
@@ -521,9 +522,9 @@ def test_warp_img_transform():
     _ = cx.bounds2raster(
         w, s, e, n, "test.tif", zoom=4, ll=True, source=cx.providers.CartoDB.Positron
     )
-    rtr = rio.open("test.tif")
-    img = np.array([band for band in rtr.read()])
-    wimg, _ = cx.warp_img_transform(img, rtr.transform, rtr.crs, "epsg:4326")
+    with rio.open("test.tif") as rtr:
+        img = np.array([band for band in rtr.read()])
+        wimg, _ = cx.warp_img_transform(img, rtr.transform, rtr.crs, "epsg:4326")
     # Check approximate pixel values instead of exact matches for robustness
     assert np.allclose(wimg[:, 100, 100], [249, 249, 247, 255], atol=10)
     assert np.allclose(wimg[:, 100, 200], [250, 250, 248, 255], atol=10)
@@ -553,9 +554,9 @@ def test_ll2wdw():
     )
     hou = (-10676650.69219051, 3441477.046670125, -10576977.7804825, 3523606.146650609)
     _ = cx.bounds2raster(w, s, e, n, "test.tif", zoom=4, ll=True)
-    rtr = rio.open("test.tif")
-    wdw = cx.tile.bb2wdw(hou, rtr)
-    assert wdw == ((152, 161), (189, 199))
+    with rio.open("test.tif") as rtr:
+        wdw = cx.tile.bb2wdw(hou, rtr)
+        assert wdw == ((152, 161), (189, 199))
 
 
 def test__sm2ll():
@@ -618,7 +619,10 @@ def test_place():
         4891969.810251278,
     ]
     expected_zoom = 10
-    loc = cx.Place(SEARCH, zoom_adjust=ADJUST)
+
+    # Use a geocoder with increased timeout to avoid flaky network issues
+    geocoder = geopy.geocoders.Nominatim(user_agent="contextily_test", timeout=10)
+    loc = cx.Place(SEARCH, zoom_adjust=ADJUST, geocoder=geocoder)
     assert loc.im.shape == (256, 256, 4)
     loc  # Make sure repr works
 
@@ -628,7 +632,7 @@ def test_place():
     assert_array_almost_equal(loc.bbox_map, expected_bbox_map)
     assert loc.zoom == expected_zoom
 
-    loc = cx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
+    loc = cx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST, geocoder=geocoder)
     assert os.path.exists("./test2.tif")
 
     # .plot() method
@@ -686,7 +690,10 @@ def test_add_basemap_local_source():
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(subset[0], subset[1])
     ax.set_ylim(subset[2], subset[3])
-    _ = cx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
+
+    # Use a geocoder with increased timeout to avoid flaky network issues
+    geocoder = geopy.geocoders.Nominatim(user_agent="contextily_test", timeout=10)
+    _ = cx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST, geocoder=geocoder)
     cx.add_basemap(ax, source="./test2.tif", reset_extent=True)
 
     assert_array_almost_equal(subset, ax.images[0].get_extent())
@@ -739,7 +746,10 @@ def test_add_basemap_full_read():
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    loc = cx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
+
+    # Use a geocoder with increased timeout to avoid flaky network issues
+    geocoder = geopy.geocoders.Nominatim(user_agent="contextily_test", timeout=10)
+    loc = cx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST, geocoder=geocoder)
     cx.add_basemap(ax, source="./test2.tif", reset_extent=False)
 
     raster_extent = (

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -16,7 +16,7 @@ def test_providers():
         cx.providers.OpenStreetMap.Mapnik,
         cx.providers.NASAGIBS.ViirsEarthAtNight2012,
     ]:
-        cx.bounds2img(w, s, e, n, 4, source=provider, ll=True)
+        cx.bounds2img(w, s, e, n, 4, source=provider, ll=True, max_retries=20)
 
 def test_invalid_provider():
     w, s, e, n = (-106.649, 25.845, -93.507, 36.494)


### PR DESCRIPTION
An attempt to reduce network errors during ci:
1. Set geocoder timeout to 10
2. Increase max retries to 20 in test_proivders.py

Also added rasterio context manager when reading test .tiff files. Probably not necessary. 