### PR TITLE
MNT: Improve license metadata (PEP 639)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
@@ -13,11 +13,10 @@ authors = [
 maintainers = [
     {name = "contextily contributors"},
 ]
-license = {text = "3-Clause BSD"}
+license = "BSD-3-Clause"
 description = "Context geo-tiles in Python"
 readme = "README.md"
 classifiers = [
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This improves the licence metadata to align with [PEP 639](https://peps.python.org/pep-0639/):

- Specify license as a valid SPDX text identifier (the former table structure is deprecated)
- Remove license classifier, which is deprecated

These changes clear-up warnings from the package build. It also requires setuptools>=77.